### PR TITLE
Security Export: Issues, Dependabot & CodeScan Alerts

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,3 +222,11 @@ requirements.txt      C2 server runtime deps
 ## License
 
 GPL v3. See `LICENSE`.
+
+
+---
+### Grisuno Offensive Security Ecosystem
+This tool is part of a broader, synergistic RedTeam workflow:
+- [LazyOwn](https://github.com/grisuno/LazyOwn): RedTeam/APT framework with AI-powered C&C, rootkits and malleable implants (Windows/Linux/Mac).
+- [LazyOwnBT](https://github.com/grisuno/LazyOwnBT): Advanced complementary toolkit for BlueTeam professionals.
+- [Lazymapd](https://github.com/grisuno/Lazymapd): Fast, customizable port scanner for firewall evasion.

--- a/issues/README.md
+++ b/issues/README.md
@@ -1,0 +1,22 @@
+# Repository: blacksandbeacon
+
+**Description:** Black Sand Beacon — a lightweight, memory-resident micro beacon or implant for the LazyOwn RedTeam Framework — is the first offensive platform to deliver true native BOF (Beacon Object File) support for Linux. Inspired by the Windows-based Black Basalt Beacon, it enables red teams to write position-independent, fileless post-exploitation modules
+
+| Metric | Value |
+|--------|-------|
+| Stars | 15 |
+| Clones (last 14 days) | 73 |
+| Open Issues | 2 |
+| Total Issues | 0 |
+| Dependabot Open Alerts | 1 |
+| CodeScan Open Alerts | 1 |
+
+## Issues
+
+## Dependabot Alerts
+- [Dependabot #0](./dependabot/alert_0.md) - unknown (N/A) - unknown
+
+## Code Scanning Alerts
+- [CodeScan #0](./codescan/alert_0.md) - N/A (N/A) - unknown
+
+Total issues downloaded: 0

--- a/issues/codescan/alert_0.md
+++ b/issues/codescan/alert_0.md
@@ -1,0 +1,10 @@
+# Code Scanning Alert #0: N/A
+
+- **State:** unknown
+- **Severity:** N/A
+- **Tool:** unknown
+- **Created:** 
+- **URL:** 
+
+## Description
+

--- a/issues/dependabot/alert_0.md
+++ b/issues/dependabot/alert_0.md
@@ -1,0 +1,13 @@
+# Dependabot Alert #0: unknown
+
+- **State:** unknown
+- **Severity:** N/A
+- **CVE:** N/A
+- **Created:** 
+- **URL:** 
+
+## Summary
+
+
+## Description
+


### PR DESCRIPTION
Automated security export generated on 20260904_021811.

This PR adds a snapshot under `issues/` with:
- All GitHub issues (open + closed) as `issue_<n>.md`
- Open Dependabot alerts under `issues/dependabot/`
- Open Code Scanning alerts under `issues/codescan/`
- Index in `issues/README.md`

Additionally, cross-repo discovery network links have been injected into the project README.md to connect related repositories in the Grisuno ecosystem.

Each run replaces this branch (and closes any previous PR using the same head), so only the latest snapshot is open at any time.

Generated by `security_issue_progressive.sh`.